### PR TITLE
deps: Specify superstring as a tarball URL, not a git URL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "dugite": "^2.1.0",
-        "superstring": "https://github.com/pulsar-edit/superstring#c2ff062317362363eae7d392cd78aef4fcc8b9f8",
+        "superstring": "https://github.com/pulsar-edit/superstring/archive/c2ff062317362363eae7d392cd78aef4fcc8b9f8.tar.gz",
         "what-the-diff": "^0.6.0"
       },
       "devDependencies": {
@@ -2362,8 +2362,8 @@
     },
     "node_modules/superstring": {
       "version": "2.4.4",
-      "resolved": "git+ssh://git@github.com/pulsar-edit/superstring.git#c2ff062317362363eae7d392cd78aef4fcc8b9f8",
-      "integrity": "sha512-y9GbiqAvW1Fd7P1BS0LuDiywN7Ww+/tE//jaWSca63Rr1KXeQ4avAnEsGswuyqowMS9FHOI9aykjICS5tj6wOA==",
+      "resolved": "https://github.com/pulsar-edit/superstring/archive/c2ff062317362363eae7d392cd78aef4fcc8b9f8.tar.gz",
+      "integrity": "sha512-8YHe3s9HxrlK0MTMhF/nv5Gk68h8yI9l/2KsdqIXkXYQgRcHitwOh4sxRhl+DC+VK29rD2kVbj7uc3IV++luSQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -4582,9 +4582,8 @@
       "dev": true
     },
     "superstring": {
-      "version": "git+ssh://git@github.com/pulsar-edit/superstring.git#c2ff062317362363eae7d392cd78aef4fcc8b9f8",
-      "integrity": "sha512-y9GbiqAvW1Fd7P1BS0LuDiywN7Ww+/tE//jaWSca63Rr1KXeQ4avAnEsGswuyqowMS9FHOI9aykjICS5tj6wOA==",
-      "from": "superstring@https://github.com/pulsar-edit/superstring#c2ff062317362363eae7d392cd78aef4fcc8b9f8",
+      "version": "https://github.com/pulsar-edit/superstring/archive/c2ff062317362363eae7d392cd78aef4fcc8b9f8.tar.gz",
+      "integrity": "sha512-8YHe3s9HxrlK0MTMhF/nv5Gk68h8yI9l/2KsdqIXkXYQgRcHitwOh4sxRhl+DC+VK29rD2kVbj7uc3IV++luSQ==",
       "requires": {
         "nan": "^2.14.2"
       },

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "dugite": "^2.1.0",
-    "superstring": "https://github.com/pulsar-edit/superstring#c2ff062317362363eae7d392cd78aef4fcc8b9f8",
+    "superstring": "https://github.com/pulsar-edit/superstring/archive/c2ff062317362363eae7d392cd78aef4fcc8b9f8.tar.gz",
     "what-the-diff": "^0.6.0"
   }
 }


### PR DESCRIPTION
Specified the `superstring` dependency as as a tarball URL in `package.json`, not as a git URL.

Motivation:

Tarballs are the simpler format for package managers to handle.

(Git URLs are cloned into a temp dir, installed there, then the result is copied. Tarballs are simply fetched and extracted.)

In my opinion, for reasons of performance and simplicity, tarballs should be preferred over git URLs in `package.json`, where possible.

_(Note: I forgot to do it this way in https://github.com/pulsar-edit/whats-my-line/pull/5, but I remembered while I was going over to update \*this\* package as a dependency in the `github` package repo. I figured I can circle back and do it now.)_