### PR TITLE
Pin `dugite` to `2.1.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.2.0",
       "license": "ISC",
       "dependencies": {
-        "dugite": "^2.1.0",
+        "dugite": "2.1.0",
         "superstring": "https://github.com/pulsar-edit/superstring/archive/c2ff062317362363eae7d392cd78aef4fcc8b9f8.tar.gz",
         "what-the-diff": "^0.6.0"
       },
@@ -509,9 +509,9 @@
       }
     },
     "node_modules/dugite": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/dugite/-/dugite-2.5.1.tgz",
-      "integrity": "sha512-9OjUguynzq8v3GSmp01kbVcMmErc65ZZ0OssO/0PM2RyhD8Dzb8cCuy3z72+IxLwPwNi754jZ0FtMLAFA3D0qA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/dugite/-/dugite-2.1.0.tgz",
+      "integrity": "sha512-4l4jJz5zC6Q+/8doQNQZ9Ss3rmnO/JCHfOmQO+zGv+TIOUXimzfS02RvUOuFpEhZuaFTeFBSuK6ll/02TX3SxA==",
       "hasInstallScript": true,
       "dependencies": {
         "progress": "^2.0.3",
@@ -3119,9 +3119,9 @@
       "dev": true
     },
     "dugite": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/dugite/-/dugite-2.5.1.tgz",
-      "integrity": "sha512-9OjUguynzq8v3GSmp01kbVcMmErc65ZZ0OssO/0PM2RyhD8Dzb8cCuy3z72+IxLwPwNi754jZ0FtMLAFA3D0qA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/dugite/-/dugite-2.1.0.tgz",
+      "integrity": "sha512-4l4jJz5zC6Q+/8doQNQZ9Ss3rmnO/JCHfOmQO+zGv+TIOUXimzfS02RvUOuFpEhZuaFTeFBSuK6ll/02TX3SxA==",
       "requires": {
         "progress": "^2.0.3",
         "tar": "^6.1.11"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "mocha": "^6.0.2"
   },
   "dependencies": {
-    "dugite": "^2.1.0",
+    "dugite": "2.1.0",
     "superstring": "https://github.com/pulsar-edit/superstring/archive/c2ff062317362363eae7d392cd78aef4fcc8b9f8.tar.gz",
     "what-the-diff": "^0.6.0"
   }


### PR DESCRIPTION
This PR pins `dugite` to `2.1.0`. Really only because this is the same version pinned within the `github` package.

Which is used by this dep, and we would like to sync these two deps perfectly to reduce the amount of times that `dugite` is installed into Pulsar