### PR TITLE
Set up CI publishing pipeline to NPM

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,33 @@
+name: NPM Publish
+
+on:
+  release:
+    types: [created]
+  workflow_dispatch:
+
+env:
+  NODE_VERSION: 16
+  NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - run: npm ci
+      - run: npm test
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npm publish --access public

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
+      # This is needed for Python 3.12+, since many versions of node-gyp
+      # are incompatible with Python 3.12+, which no-longer ships 'distutils'
+      # out of the box. 'setuptools' package provides 'distutils'.
+      - run: python3 -m pip install --break-system-packages setuptools
       - run: npm ci
       - run: npm test
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       # This is needed for Python 3.12+, since many versions of node-gyp
       # are incompatible with Python 3.12+, which no-longer ships 'distutils'
       # out of the box. 'setuptools' package provides 'distutils'.
-      run: python3 -m pip install setuptools
+      run: python3 -m pip install --user setuptools
     - name: Setup Node
       uses: actions/setup-node@v3
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       # This is needed for Python 3.12+, since many versions of node-gyp
       # are incompatible with Python 3.12+, which no-longer ships 'distutils'
       # out of the box. 'setuptools' package provides 'distutils'.
-      run: python3 -m pip --break-system-packages install setuptools
+      run: pip3 --break-system-packages install setuptools
     - name: Setup Node
       uses: actions/setup-node@v3
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       # This is needed for Python 3.12+, since many versions of node-gyp
       # are incompatible with Python 3.12+, which no-longer ships 'distutils'
       # out of the box. 'setuptools' package provides 'distutils'.
-      run: pip install setuptools
+      run: python3 -m pip install setuptools
     - name: Setup Node
       uses: actions/setup-node@v3
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        node-version: [ 16, 18 ]
+        node-version: [ 16 ]
       fail-fast: false
     name: Test
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,9 @@ jobs:
     name: Test
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Install dependencies
+      if: runner.os == 'macOS'
+      run: brew install libiconv
     - name: Checkout the latest code
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       # This is needed for Python 3.12+, since many versions of node-gyp
       # are incompatible with Python 3.12+, which no-longer ships 'distutils'
       # out of the box. 'setuptools' package provides 'distutils'.
-      run: python3 -m pip install setuptools --config-settings=global.break-system-packages=true
+      run: python3 -m pip install setuptools --config-settings=break-system-packages=true
     - name: Setup Node
       uses: actions/setup-node@v3
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       # This is needed for Python 3.12+, since many versions of node-gyp
       # are incompatible with Python 3.12+, which no-longer ships 'distutils'
       # out of the box. 'setuptools' package provides 'distutils'.
-      run: python3 -m pip install setuptools --config-settings=break-system-packages=true
+      run: python3 -m pip install --break-system-packages setuptools
     - name: Setup Node
       uses: actions/setup-node@v3
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       # This is needed for Python 3.12+, since many versions of node-gyp
       # are incompatible with Python 3.12+, which no-longer ships 'distutils'
       # out of the box. 'setuptools' package provides 'distutils'.
-      run: pip3 --break-system-packages install setuptools
+      run: pip install setuptools
     - name: Setup Node
       uses: actions/setup-node@v3
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
         # Make sure we get all commits, since testing uses the local git info
     - name: Override pip warning
       if: runner.os == 'macOS'
-      run: echo "break-system-packages = true" > ~/.pip/pip.conf
+      run: mkdir -p ~/.pip && echo "break-system-packages = true" > ~/.pip/pip.conf
     - name: Install Python setuptools
       # This is needed for Python 3.12+, since many versions of node-gyp
       # are incompatible with Python 3.12+, which no-longer ships 'distutils'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,9 @@ jobs:
       with:
         fetch-depth: 0
         # Make sure we get all commits, since testing uses the local git info
+    - name: Override pip warning
+      if: runner.os == 'macOS'
+      run: echo "break-system-packages = true" > ~/.pip/pip.conf
     - name: Install Python setuptools
       # This is needed for Python 3.12+, since many versions of node-gyp
       # are incompatible with Python 3.12+, which no-longer ships 'distutils'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       # This is needed for Python 3.12+, since many versions of node-gyp
       # are incompatible with Python 3.12+, which no-longer ships 'distutils'
       # out of the box. 'setuptools' package provides 'distutils'.
-      run: python3 -m pip install setuptools
+      run: python3 -m pip --break-system-packages install setuptools
     - name: Setup Node
       uses: actions/setup-node@v3
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
         # Make sure we get all commits, since testing uses the local git info
     - name: Override pip warning
       if: runner.os == 'macOS'
-      run: mkdir -p ~/.pip && echo "break-system-packages = true" > ~/.pip/pip.conf
+      run: mkdir -p ~/.pip && echo "[global]\nbreak-system-packages = true" > ~/.pip/pip.conf
     - name: Install Python setuptools
       # This is needed for Python 3.12+, since many versions of node-gyp
       # are incompatible with Python 3.12+, which no-longer ships 'distutils'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,14 +20,11 @@ jobs:
       with:
         fetch-depth: 0
         # Make sure we get all commits, since testing uses the local git info
-    - name: Override pip warning
-      if: runner.os == 'macOS'
-      run: mkdir -p ~/.pip && echo "[global]\nbreak-system-packages = true" > ~/.pip/pip.conf
     - name: Install Python setuptools
       # This is needed for Python 3.12+, since many versions of node-gyp
       # are incompatible with Python 3.12+, which no-longer ships 'distutils'
       # out of the box. 'setuptools' package provides 'distutils'.
-      run: python3 -m pip install --user setuptools
+      run: python3 -m pip install setuptools --config-settings=global.break-system-packages=true
     - name: Setup Node
       uses: actions/setup-node@v3
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 **/dist
+.tool-versions

--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,5 @@ src
 test
 img
 tsconfig.json
+.tool-versions
+.github

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "comment",
     "diff"
   ],
+  "engines": {
+    "node": ">=14 <=16"
+  },
   "author": "kuychaco",
   "license": "ISC",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "dugite": "2.5.2",
-    "superstring": "https://github.com/pulsar-edit/superstring/archive/c2ff062317362363eae7d392cd78aef4fcc8b9f8.tar.gz",
+    "superstring": "github:pulsar-edit/superstring#de97b496663fce40050bf2d66e1466ccfbd00943",
     "what-the-diff": "^0.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "whats-my-line",
+  "name": "@pulsar-edit/whats-my-line",
   "version": "0.2.0",
   "description": "Handy library for displaying GitHub comments within a text editor.",
   "main": "src/index.js",


### PR DESCRIPTION
Proceeding down [my checklist](https://gist.github.com/savetheclocktower/b3655727786e264d841db5d403a4a771?permalink_comment_id=5450119#gistcomment-5450119), here's the next package to start publishing to NPM.

[As with `fuzzy-native`](https://github.com/pulsar-edit/fuzzy-native/pull/6), Pulsar stable is pinned to an older commit. Since the version number has been bumped since then (from `0.1.4` to `0.2.0`), we're already set up to do [what I describe in this comment](https://github.com/pulsar-edit/fuzzy-native/pull/6#issuecomment-2689367769) — see if the latest version works, then fall back to publishing the old commit as `0.1.5`.

The pipeline for ascertaining that `0.2.0` will work is… a bit longer, sadly, since it would require updating the `github` package's dependency first, then bumping _that_, then ensuring it works in stable Pulsar.