### PR TITLE
Switch to `@pulsar-edit/superstring` version 3

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 env:
-  NODE_VERSION: 16
+  NODE_VERSION: 20
   NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        node-version: [ 16 ]
+        node-version: [ 20 ]
       fail-fast: false
     name: Test
     runs-on: ${{ matrix.os }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,36 @@
 {
-  "name": "whats-my-line",
+  "name": "@pulsar-edit/whats-my-line",
   "version": "0.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "whats-my-line",
+      "name": "@pulsar-edit/whats-my-line",
       "version": "0.2.1",
       "license": "ISC",
       "dependencies": {
+        "@pulsar-edit/superstring": "^3.0.4",
         "dugite": "2.5.2",
-        "superstring": "^2.4.4",
         "what-the-diff": "^0.6.0"
       },
       "devDependencies": {
         "js-yaml": "^3.12.2",
         "mocha": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@pulsar-edit/superstring": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@pulsar-edit/superstring/-/superstring-3.0.4.tgz",
+      "integrity": "sha512-2gAZOOMCcwjLmFAojiBwyk/4aoj29jezZ80bH+7axjg8/6lFQk63L0Mu3+/lwSjDYMQ1XU6ebZGhBhHHtFSXYA==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "node-addon-api": "^8.5.0"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/ansi-colors": {
@@ -1675,6 +1690,14 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "node_modules/node-addon-api": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.5.0.tgz",
+      "integrity": "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
     "node_modules/node-environment-flags": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.4.tgz",
@@ -2360,20 +2383,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/superstring": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/superstring/-/superstring-2.4.4.tgz",
-      "integrity": "sha512-41LWIGzy6tkUM6jUwbXTeGOLui3gGBxgV6m8gIWRzv1WdW0HV6oANHdGanRrM04mwFXXExII9OQ/XxaqU+Ft9w==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "nan": "^2.14.2"
-      }
-    },
-    "node_modules/superstring/node_modules/nan": {
-      "version": "2.14.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
-      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
-    },
     "node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -2727,6 +2736,14 @@
     }
   },
   "dependencies": {
+    "@pulsar-edit/superstring": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@pulsar-edit/superstring/-/superstring-3.0.4.tgz",
+      "integrity": "sha512-2gAZOOMCcwjLmFAojiBwyk/4aoj29jezZ80bH+7axjg8/6lFQk63L0Mu3+/lwSjDYMQ1XU6ebZGhBhHHtFSXYA==",
+      "requires": {
+        "node-addon-api": "^8.5.0"
+      }
+    },
     "ansi-colors": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
@@ -4046,6 +4063,11 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "node-addon-api": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.5.0.tgz",
+      "integrity": "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A=="
+    },
     "node-environment-flags": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.4.tgz",
@@ -4579,21 +4601,6 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
-    },
-    "superstring": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/superstring/-/superstring-2.4.4.tgz",
-      "integrity": "sha512-41LWIGzy6tkUM6jUwbXTeGOLui3gGBxgV6m8gIWRzv1WdW0HV6oANHdGanRrM04mwFXXExII9OQ/XxaqU+Ft9w==",
-      "requires": {
-        "nan": "^2.14.2"
-      },
-      "dependencies": {
-        "nan": {
-          "version": "2.14.2",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
-          "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
-        }
-      }
     },
     "supports-color": {
       "version": "5.5.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "diff"
   ],
   "engines": {
-    "node": ">=14 <=16"
+    "node": ">=18"
   },
   "author": "kuychaco",
   "license": "ISC",
@@ -29,8 +29,8 @@
     "mocha": "^6.0.2"
   },
   "dependencies": {
+    "@pulsar-edit/superstring": "^3.0.4",
     "dugite": "2.5.2",
-    "superstring": "github:pulsar-edit/superstring#de97b496663fce40050bf2d66e1466ccfbd00943",
     "what-the-diff": "^0.6.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,10 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-// While a little strange, this is done to match the `dist` output of when converted from TypeScript.
+// While a little strange, this is done to match the `dist` output of when
+// converted from TypeScript.
 
 const { parse } = require("what-the-diff");
-const { MarkerIndex } = require("superstring");
+const { MarkerIndex } = require("@pulsar-edit/superstring");
 const { GitProcess } = require("dugite");
 
 async function translateLines(lines, repositoryPath, fileName, commitSha) {


### PR DESCRIPTION
After five attempts, we now have a version of `@pulsar-edit/superstring` that installs cleanly from NPM! So it's time to update `whats-my-line` to harmonize with the version of `superstring` that will also be used directly by PulsarNext.

This is just like the PR that resulted in `v0.2.1`, but minus `superstring@2` and with `@pulsar-edit/superstring@3`. It also updates the `engines` field (to better agree with the range of Node versions supported by `superstring@3`) and changes the CI to use Node 20 (which is the same major version used by PulsarNext on Electron 30).

If this goes well, we'll land it, bump the version, and publish it as `@pulsar-edit/whats-my-line@0.3.0`. Then the `github` package we ship for PulsarNext can be updated to use it alongside `dugite@2.5.2`.

(I confess to forgetting why we have a branch called `just-the-dugite-2.5.2-bump`, and why it isn't just `master`. But we can figure that part out later.)